### PR TITLE
Small optimisation in InspectAssembly's GetFiles

### DIFF
--- a/InspectAssembly/Program.cs
+++ b/InspectAssembly/Program.cs
@@ -150,7 +150,11 @@ Arguments:
                     } catch { }
                 } else
                 {
-                    foreach(var f in Directory.GetFiles(path))
+                    IEnumerable<string> files;
+                    var exes = Directory.GetFiles(path, "*.exe"); // ~320
+                    var dlls = Directory.GetFiles(path, "*.dll"); // ~2800
+                    files = exes.Concat(dlls);
+                    foreach (var f in files)
                     {
                         try
                         {


### PR DESCRIPTION
This replaces the single `Directory.GetFiles` call in `InspectAssembly` with two calls that only grab `.exe` and `.dll` files.  In my very limited testing when enumerating the whole of `C:\Windows\System32`, it reduces the file count by a few hundred and saves about half a second when iterating over them with `GetAssemblyName`.

Even though the final count of the result list was no different with these filters, I'm not sure if there are cases where you need to find files of different extensions?