### PR TITLE
Recursive search and third-party filter for InspectAssembly; automatic reg query for COMHunter

### DIFF
--- a/COMHunter/Program.cs
+++ b/COMHunter/Program.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿using Microsoft.Win32;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management;
+using System.Reflection;
 
 namespace COMHunter
 {
@@ -16,7 +18,7 @@ namespace COMHunter
             public string ServerPath;
             public string Type;
         }
-        
+
         static void Main(string[] args)
         {
             List<COMServer> servers = new List<COMServer>();
@@ -26,11 +28,11 @@ namespace COMHunter
                 servers = WMICollection("InprocServer32");
                 servers.AddRange(WMICollection("LocalServer32"));
             }
-            else if(args[0] == "-inproc")
+            else if (args[0].ToLower() == "-inproc")
             {
                 servers = WMICollection("InprocServer32");
             }
-            else if (args[0] == "-localserver")
+            else if (args[0].ToLower() == "-localserver")
             {
                 servers = WMICollection("LocalServer32");
             }
@@ -40,9 +42,33 @@ namespace COMHunter
                 return;
             }
 
+            string[] defaultMethods = new string[] { "Equals", "GetHashCode", "GetType", "ToString" };
+
             foreach (COMServer server in servers)
             {
                 Console.WriteLine("{0} {1} ({2})", server.CLSID, server.ServerPath, server.Type);
+
+                // If the COM server is a .NET assembly, get the path of the actual DLL
+                if (server.ServerPath.ToLower().Contains("mscoree.dll"))
+                {
+                    object assembly = Registry.GetValue(string.Format("HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\CLSID\\{0}\\InprocServer32\\1.0.0.0", server.CLSID), "CodeBase", null);
+
+                    if (assembly != null)
+                    {
+                        Console.WriteLine(string.Format(".NET Assembly: {0}", assembly));
+
+                        Type assembly_type = Type.GetTypeFromCLSID(Guid.Parse(server.CLSID));
+
+                        foreach (MethodInfo mInfo in assembly_type.GetMethods())
+                        {
+                            // Print any non-default methods defined in the DLL
+                            if (!defaultMethods.Any(s => mInfo.Name.Contains(s)))
+                            {
+                                Console.WriteLine(string.Format("  Method: {0}", mInfo.Name));
+                            }
+                        }
+                    }
+                }
             }
             return;
         }
@@ -52,7 +78,7 @@ namespace COMHunter
             List<COMServer> comServers = new List<COMServer>();
             try
             {
-                ManagementObjectSearcher searcher =new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_ClassicCOMClassSetting");
+                ManagementObjectSearcher searcher = new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_ClassicCOMClassSetting");
                 foreach (ManagementObject queryObj in searcher.Get())
                 {
                     // Collect InProcServer32 values
@@ -60,7 +86,8 @@ namespace COMHunter
                     string svr = Environment.ExpandEnvironmentVariables(svrObj).Trim('"');
 
                     if (!string.IsNullOrEmpty(svr)
-                        && svr.ToLower().StartsWith(@"c:\") // Filter out things like combase.dll and ole32.dll
+                        // Commented out so COMHunter can find "mscoree.dll" which is used by .NET assemblies
+                        //&& svr.ToLower().StartsWith(@"c:\") // Filter out things like combase.dll and ole32.dll
                         && !svr.ToLower().Contains(@"c:\windows\") // Ignore OS components
                         && File.Exists(svr)) // Make sure the file exists
                     {


### PR DESCRIPTION
- InspectAssembly
  - Adds options to search recursively (-r, --recurse ) and only show non-Microsoft assemblies (--third-party).
  - Prints additional info about assembly to aid triage.
  - Allows a path and PID(s) to be specified in a single command.
  - Changes error messages to use STDERR.
  - Minor reformatting to enhance readability.

- COMHunter
  - Modify COMHunter to automatically query the registry for the path of .NET DLLs and print any non-default functions they define.
  - Remove case-sensitivity from COMHunter arguments to improve usability